### PR TITLE
Chain mixins

### DIFF
--- a/src/mixins/validate-mixin.ts
+++ b/src/mixins/validate-mixin.ts
@@ -1,13 +1,20 @@
 import {
-  interfaceOfPuppet,
-  looseInstanceOfPuppet,
-}                             from '../puppet/interface-of.js'
+  Constructor,
+  interfaceOfClass,
+  looseInstanceOfClass,
+} from 'clone-class'
 
-import type { Puppet }          from '../puppet/puppet-abstract.js'
-import type { PuppetInterface } from '../puppet/interface.js'
-import type { PuppetSkeleton }   from '../puppet/puppet-skeleton.js'
+import type {
+  PuppetProtectedProperty,
+} from '../puppet/interface.js'
 
-const validateMixin = <MixinBase extends typeof PuppetSkeleton>(mixinBase: MixinBase) => {
+import type { PuppetSkeleton } from '../puppet/puppet-skeleton.js'
+
+const validateMixin = <MixinBase extends typeof PuppetSkeleton>(
+  mixinBase: MixinBase,
+) => {
+  type Puppet = typeof mixinBase
+  type PuppetInterface = Omit<Puppet, PuppetProtectedProperty>
 
   abstract class ValidateMixin extends mixinBase {
 
@@ -15,14 +22,14 @@ const validateMixin = <MixinBase extends typeof PuppetSkeleton>(mixinBase: Mixin
      * Check if obj satisfy Puppet interface
      */
     static validInterface (target: any): target is PuppetInterface {
-      return interfaceOfPuppet(target)
+      return interfaceOfClass(mixinBase as any as Constructor<Puppet>)<PuppetInterface>()(target)
     }
 
     /**
      * loose check instance of Puppet
      */
     static validInstance (target: any): target is Puppet {
-      return looseInstanceOfPuppet(target)
+      return looseInstanceOfClass(mixinBase as any as Constructor<Puppet>)(target)
     }
 
     /**
@@ -42,17 +49,14 @@ const validateMixin = <MixinBase extends typeof PuppetSkeleton>(mixinBase: Mixin
   return ValidateMixin
 }
 
-type ValidateMixin = ReturnType<typeof validateMixin>
+type ValidateMixin = ReturnType<typeof validateMixin>;
 
 /**
  * Huan(202110): it seems that that static properties should not be mixed in
  */
-type ProtectedPropertyValidateMixin = never
+type ProtectedPropertyValidateMixin = never;
 // | 'validInterface'
 // | 'validInstance'
 
-export type {
-  ProtectedPropertyValidateMixin,
-  ValidateMixin,
-}
+export type { ProtectedPropertyValidateMixin, ValidateMixin }
 export { validateMixin }

--- a/src/puppet/puppet-abstract.ts
+++ b/src/puppet/puppet-abstract.ts
@@ -43,44 +43,20 @@ import {
 
 import { PuppetSkeleton } from './puppet-skeleton.js'
 
-/**
- * Huan(202110): use compose() to compose mixins
- */
-
-// const MixinBase = compose(
-//   messageMixin,
-//   roomInvitationMixin,
-//   ...,
-//   PuppetSkeleton,
-// )
-
-const MixinBase = miscMixin(
-  serviceMixin(
-    validateMixin(
-      messageMixin(
-        roomInvitationMixin(
-          tagMixin(
-            friendshipMixin(
-              roomMixin(
-                roomMemberMixin(
-                  contactMixin(
-                    loginMixin(
-                      cacheMixin(
-                        memoryMixin(
-                          PuppetSkeleton,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    ),
-  ),
-)
+const MixinBase = PuppetSkeleton
+  .chain(memoryMixin)
+  .chain(cacheMixin)
+  .chain(loginMixin)
+  .chain(contactMixin)
+  .chain(roomMemberMixin)
+  .chain(roomMixin)
+  .chain(friendshipMixin)
+  .chain(tagMixin)
+  .chain(roomInvitationMixin)
+  .chain(messageMixin)
+  .chain(validateMixin)
+  .chain(serviceMixin)
+  .chain(miscMixin)
 
 /**
  *

--- a/src/puppet/puppet-skeleton.ts
+++ b/src/puppet/puppet-skeleton.ts
@@ -56,8 +56,8 @@ abstract class PuppetSkeleton extends PuppetEventEmitter {
    */
   readonly id: string
 
-  _flagSkeletonStartCalled : boolean
-  _flagSkeletonStopCalled  : boolean
+  _flagSkeletonStartCalled: boolean
+  _flagSkeletonStopCalled: boolean
 
   readonly options: PuppetOptions
 
@@ -86,11 +86,11 @@ abstract class PuppetSkeleton extends PuppetEventEmitter {
         : '',
     )
 
-    this.id       = UUID.v4()
-    this.options  = args[0] || {}
+    this.id = UUID.v4()
+    this.options = args[0] || {}
 
     this._flagSkeletonStartCalled = false
-    this._flagSkeletonStopCalled  = false
+    this._flagSkeletonStopCalled = false
   }
 
   /**
@@ -107,7 +107,7 @@ abstract class PuppetSkeleton extends PuppetEventEmitter {
 
   async stop (): Promise<void> {
     log.verbose('PuppetSkeleton', 'stop()')
-    this._flagSkeletonStopCalled  = true
+    this._flagSkeletonStopCalled = true
   }
 
   /**
@@ -137,6 +137,10 @@ abstract class PuppetSkeleton extends PuppetEventEmitter {
     }
 
     return super.emit('error', payload)
+  }
+
+  static chain<T, Derived> (this: T, fn: (base: T) => Derived): Derived {
+    return fn(this)
   }
 
 }


### PR DESCRIPTION
Since `@qiwi/mixin` also uses `Object.defineProperty` under the hood, I gave up the attempt on using that package.

Instead, I defined a new `chain` method on the `PuppetSkeleton` class, and use the method to chain the mixin functions.

However, I ran into a problem because `ValidateMixin` uses `Puppet`, which is actually its child. So I modify the `ValidateMixin` class to adapt it to the `.chain()` method.

Everything works fine. But I need @huan to check if the modifications to `ValidateMixin` are OK.